### PR TITLE
Fix typo rx= to ry=

### DIFF
--- a/dist/examples/svg/svg-ellipse.js
+++ b/dist/examples/svg/svg-ellipse.js
@@ -63,7 +63,7 @@ let tag = text.tspan('&lt;ellipse ');
 let cx = text.tspan('cx=');
 let cy = text.tspan('cy=');
 let rx = text.tspan('rx=');
-let ry = text.tspan('rx=');
+let ry = text.tspan('ry=');
 let close = text.tspan('&gt;&lt;/ellipse&gt;');
 text.x = 20;
 text.y = interactive.maxY - 20;


### PR DESCRIPTION
I noticed that rx= was duplicated in SVG example webpage although it had to be ry=